### PR TITLE
Fix README pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Features/Goals
 Usage
 -----
 
-To use TextUI, see the main.py for now.
+To use TextUI, review `examples/sample_markup.xml` or the module `textui/textui.py` for now.
 ```
 
 ...


### PR DESCRIPTION
## Summary
- update the usage section of the README to point to working sample files

## Testing
- `PYTHONPATH=$PYTHONPATH:./textui pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684067c3217883258db6ab1080775a39