### PR TITLE
Add script node handling

### DIFF
--- a/tests/test_script_node.py
+++ b/tests/test_script_node.py
@@ -1,0 +1,7 @@
+from textui.textui import TextUI
+
+def test_script_node_execution():
+    markup = "<container><script>app.executed = True</script></container>"
+    app = TextUI(markup)
+    list(app.parse_markup())
+    assert getattr(app, "executed", False) is True

--- a/textui/defs/element_widget_definition.py
+++ b/textui/defs/element_widget_definition.py
@@ -7,6 +7,7 @@ from textual.widget import Widget
 import os
 
 from validate_css import validate_css
+import logging
 
 
 def get_absolute_path(file_path, abs_path):
@@ -46,6 +47,21 @@ def preprocess_style(element: Element, app: App) -> bool:
     css_data = validate_css(css_data)
     app.stylesheet.add_source(css_data, path="embedded_style", is_default_css=False)
     app.stylesheet.parse()
+    return False
+
+
+def preprocess_script(element: Element, app: App) -> bool:
+    """Execute the Python code contained in a <script> element.
+
+    The code is executed with the current :class:`TextUI` instance available as
+    ``app``. Any exceptions raised during execution are logged.
+    """
+    script_code = element.text or ""
+    if script_code.strip():
+        try:
+            exec(script_code, {"app": app})
+        except Exception:
+            logging.exception("Error executing script node")
     return False
 
 

--- a/textui/defs/html_defs.py
+++ b/textui/defs/html_defs.py
@@ -3,8 +3,13 @@ from xml.etree.ElementTree import Element
 from textual.app import App
 from textual.containers import Container
 
-from defs.element_widget_definition import ElementWidgetDefinition, preprocess_width_height, preprocess_style, \
-    preprocess_src
+from defs.element_widget_definition import (
+    ElementWidgetDefinition,
+    preprocess_width_height,
+    preprocess_style,
+    preprocess_src,
+    preprocess_script,
+)
 from widgets.html_widgets import Img, Div, P, Span
 
 
@@ -17,6 +22,7 @@ def preprocess_img(element: Element, app: App) -> bool:
 HTML_DEFS = [
     ElementWidgetDefinition(tag="html", widget_class=Container),
     ElementWidgetDefinition(tag="style", preprocessor=preprocess_style),
+    ElementWidgetDefinition(tag="script", preprocessor=preprocess_script),
     ElementWidgetDefinition(tag="img", widget_class=Img, preprocessor=preprocess_img),
     ElementWidgetDefinition(tag="div", widget_class=Div),
     ElementWidgetDefinition(tag="p", widget_class=P),


### PR DESCRIPTION
## Summary
- implement script element execution via preprocess function
- register `script` tag for HTML widgets
- test script node code execution

## Testing
- `PYTHONPATH=textui:. python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840688569608325ad5c001e92ca2841