### PR TITLE
Fix authors list in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "textui"
 version = "0.1.0"
 description = ""
-authors = ["thunderballfists <apb@beihl.com"]
+authors = ["thunderballfists <apb@beihl.com>"]
 readme = "README.md"
 packages = [
     { include = "textui", from = "." },


### PR DESCRIPTION
## Summary
- close the missing angle bracket in `pyproject.toml` author entry

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684067bbe8fc832582fea594ebc2523c