### PR TITLE
Add script tag test and fix imports

### DIFF
--- a/tests/test_script_node.py
+++ b/tests/test_script_node.py
@@ -1,3 +1,8 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 from textui.textui import TextUI
 
 def test_script_node_execution():
@@ -5,3 +10,12 @@ def test_script_node_execution():
     app = TextUI(markup)
     list(app.parse_markup())
     assert getattr(app, "executed", False) is True
+
+
+def test_script_tag_ignored():
+    markup = "<container><p></p><script>app.executed = True</script><p></p></container>"
+    app = TextUI(markup)
+    widgets = list(app.parse_markup())
+    assert getattr(app, "executed", False) is True
+    assert len(widgets) == 2
+    assert all(w.__class__.__name__ == "P" for w in widgets)

--- a/textui/defs/element_widget_definition.py
+++ b/textui/defs/element_widget_definition.py
@@ -6,7 +6,7 @@ from textual.widget import Widget
 
 import os
 
-from validate_css import validate_css
+from ..validate_css import validate_css
 import logging
 
 

--- a/textui/defs/html_defs.py
+++ b/textui/defs/html_defs.py
@@ -3,14 +3,14 @@ from xml.etree.ElementTree import Element
 from textual.app import App
 from textual.containers import Container
 
-from defs.element_widget_definition import (
+from .element_widget_definition import (
     ElementWidgetDefinition,
     preprocess_width_height,
     preprocess_style,
     preprocess_src,
     preprocess_script,
 )
-from widgets.html_widgets import Img, Div, P, Span
+from ..widgets.html_widgets import Img, Div, P, Span
 
 
 def preprocess_img(element: Element, app: App) -> bool:


### PR DESCRIPTION
## Summary
- fix relative imports in defs modules
- insert path setup for tests
- add test verifying script tags are executed but ignored

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68406be4b3b483258d0da1fe6f37342d