### PR TITLE
Support script language attribute

### DIFF
--- a/tests/test_script_node.py
+++ b/tests/test_script_node.py
@@ -5,15 +5,30 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from textui.textui import TextUI
 
-def test_script_node_execution():
-    markup = "<container><script>app.executed = True</script></container>"
+
+def test_script_node_execution_with_language():
+    markup = "<container><script language='python'>app.executed = True</script></container>"
     app = TextUI(markup)
     list(app.parse_markup())
     assert getattr(app, "executed", False) is True
 
 
+def test_script_node_default_language():
+    markup = "<container><script>app.default_executed = True</script></container>"
+    app = TextUI(markup)
+    list(app.parse_markup())
+    assert getattr(app, "default_executed", False) is True
+
+
+def test_script_node_unknown_language():
+    markup = "<container><script language='javascript'>app.js_executed = True</script></container>"
+    app = TextUI(markup)
+    list(app.parse_markup())
+    assert getattr(app, "js_executed", False) is False
+
+
 def test_script_tag_ignored():
-    markup = "<container><p></p><script>app.executed = True</script><p></p></container>"
+    markup = "<container><p></p><script language='python'>app.executed = True</script><p></p></container>"
     app = TextUI(markup)
     widgets = list(app.parse_markup())
     assert getattr(app, "executed", False) is True

--- a/textui/defs/element_widget_definition.py
+++ b/textui/defs/element_widget_definition.py
@@ -51,17 +51,23 @@ def preprocess_style(element: Element, app: App) -> bool:
 
 
 def preprocess_script(element: Element, app: App) -> bool:
-    """Execute the Python code contained in a <script> element.
+    """Execute code contained in a ``<script>`` element.
 
-    The code is executed with the current :class:`TextUI` instance available as
-    ``app``. Any exceptions raised during execution are logged.
+    The language of the script is determined by the ``language`` attribute. If
+    no attribute is provided, ``python`` is assumed. Only Python scripts are
+    currently supported. Scripts using unsupported languages are ignored.
     """
+    language = element.attrib.get("language", "python").lower()
     script_code = element.text or ""
-    if script_code.strip():
+
+    if language in ("py", "python") and script_code.strip():
         try:
             exec(script_code, {"app": app})
         except Exception:
             logging.exception("Error executing script node")
+    else:
+        logging.warning("Ignoring script with unsupported language '%s'", language)
+
     return False
 
 


### PR DESCRIPTION
## Summary
- extend script node preprocessing so it accepts a `language` attribute
- add tests for python/default/unknown script language behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68406d54ca5c8325bd7c649126edfc43