### PR TITLE
Fix global logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,19 @@ To use TextUI, review `examples/sample_markup.xml` or the module `textui/textui.
     app.run()
 ```
 
+Logging
+-------
+
+TextUI relies on Python's standard `logging` module. The package does not set a
+global logging level, so applications should configure logging as desired:
+
+```python
+import logging
+logging.basicConfig(level=logging.DEBUG)
+```
+
+Enabling debug output can be helpful when troubleshooting markup or CSS issues.
+
 License
 -------
 

--- a/textui/textui.py
+++ b/textui/textui.py
@@ -10,9 +10,6 @@ from .validate_css import validate_css
 from .widgets.widget_factory import ElementWidgetFactory
 from lxml import html
 
-logging.getLogger().setLevel(logging.DEBUG)
-
-
 class TextUI(App):
     def __init__(self, markup: str) -> None:
         super().__init__()


### PR DESCRIPTION
## Summary
- remove root-level debug logging in `textui.textui`
- document how to enable module-level logging in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68406f2d91a4832592997f1f1d88729c