### PR TITLE
Support multiple <style> tags

### DIFF
--- a/tests/test_style_tags.py
+++ b/tests/test_style_tags.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from textui.textui import TextUI
+
+
+def test_multiple_style_tags():
+    markup = "<container><style>.one {color: red;}</style><style>.two {color: blue;}</style></container>"
+    app = TextUI(markup)
+    list(app.parse_markup())
+
+    sources = list(app.stylesheet.source.values())
+    assert len(sources) == 2
+    assert any('.one' in source.content for source in sources)
+    assert any('.two' in source.content for source in sources)

--- a/textui/defs/element_widget_definition.py
+++ b/textui/defs/element_widget_definition.py
@@ -7,6 +7,7 @@ from textual.widget import Widget
 import os
 
 from ..validate_css import validate_css
+import uuid
 import logging
 
 
@@ -45,7 +46,8 @@ def preprocess_style(element: Element, app: App) -> bool:
     css_data = element.text
 
     css_data = validate_css(css_data)
-    app.stylesheet.add_source(css_data, path="embedded_style", is_default_css=False)
+    unique_path = f"embedded_style_{uuid.uuid4()}"
+    app.stylesheet.add_source(css_data, path=unique_path, is_default_css=False)
     app.stylesheet.parse()
     return False
 


### PR DESCRIPTION
## Summary
- generate a unique stylesheet path for every `<style>` tag
- test parsing markup with multiple style blocks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68406f30fe608325bac3a8f85dd5edad