### PR TITLE
Implement element lookup helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ To use TextUI, review `examples/sample_markup.xml` or the module `textui/textui.
 """
 
     app = MyApp(markup)
+    label = app.get_element_by_id("accent")
+    label_list = app.get_elements_by_id("accent")
     app.run()
 ```
 

--- a/textui/textui.py
+++ b/textui/textui.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import uuid
-from typing import Optional
+from typing import Optional, List
 from xml.etree.ElementTree import Element
 from textual.app import App, ComposeResult
 from textual.widget import Widget
@@ -89,6 +89,29 @@ class TextUI(App):
         for widget in composed_widgets:
             logging.info(f"Composed widget: {widget}")
             yield widget
+
+    def get_element_by_id(self, element_id: str) -> Widget:
+        """Return a widget by its id.
+
+        This is a convenience wrapper around :meth:`get_widget_by_id` to
+        maintain backwards compatibility with older examples that refer to
+        elements instead of widgets.
+        """
+
+        return self.get_widget_by_id(element_id)
+
+    def get_elements_by_id(self, element_id: str) -> List[Widget]:
+        """Return a list with the widget matching ``element_id``.
+
+        Provided for API parity with the singular version. The list will
+        contain the widget if found, otherwise it will be empty.
+        """
+
+        try:
+            widget = self.get_widget_by_id(element_id)
+        except Exception:
+            return []
+        return [widget]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- provide `get_element_by_id` and `get_elements_by_id` in TextUI
- show how to use these helpers in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407686575c8325a6d049ecf4576d37