### PR TITLE
Add DOM-like Document helper and expose in script context

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,36 @@ logging.basicConfig(level=logging.DEBUG)
 
 Enabling debug output can be helpful when troubleshooting markup or CSS issues.
 
+Document and Window Helpers
+---------------------------
+
+Scripts executed via `<script>` tags receive a ``document`` helper and ``window``
+alias. ``window`` simply refers to the ``TextUI`` instance while ``document``
+offers DOM-like utilities:
+
+``get_element_by_id(id)`` / ``get_widget_by_id(id)``
+    Retrieve a widget by its ``id``.
+``get_elements_by_class_name(cls)``
+    Query widgets with the given class.
+``get_elements_by_tag_name(tag)``
+    Query widgets by tag name.
+``add_event_listener(widget, event_cls, callback)``
+    Attach a handler to a widget event.
+
+Example:
+
+```python
+markup = "<container><button id='ok'>OK</button></container>"
+app = TextUI(markup)
+
+def on_press(event):
+    print("button pressed")
+
+button = app.document.get_widget_by_id("ok")
+app.document.add_event_listener(button, Button.Pressed, on_press)
+```
+
+
 License
 -------
 

--- a/textui/defs/element_widget_definition.py
+++ b/textui/defs/element_widget_definition.py
@@ -64,7 +64,7 @@ def preprocess_script(element: Element, app: App) -> bool:
 
     if language in ("py", "python") and script_code.strip():
         try:
-            exec(script_code, {"app": app})
+            exec(script_code, {"app": app, "window": app, "document": app.document})
         except Exception:
             logging.exception("Error executing script node")
     else:

--- a/textui/document.py
+++ b/textui/document.py
@@ -1,0 +1,24 @@
+class Document:
+    """Helper providing DOM-like methods for TextUI applications."""
+
+    def __init__(self, app):
+        self.app = app
+
+    def get_element_by_id(self, id):
+        """Return the first widget with the given id."""
+        return self.app.query_one(f"#{id}")
+
+    # Alias
+    get_widget_by_id = get_element_by_id
+
+    def get_elements_by_class_name(self, cls):
+        """Return widgets matching the given class name."""
+        return self.app.query(f".{cls}")
+
+    def get_elements_by_tag_name(self, tag):
+        """Return widgets matching the given tag name."""
+        return self.app.query(tag)
+
+    def add_event_listener(self, widget, event_cls, callback):
+        """Register an event handler on ``widget``."""
+        widget.on(event_cls, callback)

--- a/textui/textui.py
+++ b/textui/textui.py
@@ -8,12 +8,15 @@ from textual.widget import Widget
 
 from .validate_css import validate_css
 from .widgets.widget_factory import ElementWidgetFactory
+from .document import Document
 from lxml import html
 
 class TextUI(App):
     def __init__(self, markup: str) -> None:
         super().__init__()
         self.widget_factory = ElementWidgetFactory()
+        self.document = Document(self)
+        self.window = self
 
         if os.path.isfile(markup):
             self.markup_path = os.path.abspath(markup)


### PR DESCRIPTION
## Summary
- implement `Document` helper with DOM-style query methods and event registration
- expose `document` and `window` in `TextUI` constructor
- execute `<script>` code with access to `window` and `document`
- document new API in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407680d3208325980862c456b7edaf