### PR TITLE
Defer script execution until mount

### DIFF
--- a/tests/test_script_node.py
+++ b/tests/test_script_node.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import asyncio
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -9,28 +10,32 @@ from textui.textui import TextUI
 def test_script_node_execution_with_language():
     markup = "<container><script language='python'>app.executed = True</script></container>"
     app = TextUI(markup)
-    list(app.parse_markup())
+    list(app.compose())
+    asyncio.run(app.on_mount())
     assert getattr(app, "executed", False) is True
 
 
 def test_script_node_default_language():
     markup = "<container><script>app.default_executed = True</script></container>"
     app = TextUI(markup)
-    list(app.parse_markup())
+    list(app.compose())
+    asyncio.run(app.on_mount())
     assert getattr(app, "default_executed", False) is True
 
 
 def test_script_node_unknown_language():
     markup = "<container><script language='javascript'>app.js_executed = True</script></container>"
     app = TextUI(markup)
-    list(app.parse_markup())
+    list(app.compose())
+    asyncio.run(app.on_mount())
     assert getattr(app, "js_executed", False) is False
 
 
 def test_script_tag_ignored():
     markup = "<container><p></p><script language='python'>app.executed = True</script><p></p></container>"
     app = TextUI(markup)
-    widgets = list(app.parse_markup())
+    widgets = list(app.compose())
+    asyncio.run(app.on_mount())
     assert getattr(app, "executed", False) is True
     assert len(widgets) == 2
     assert all(w.__class__.__name__ == "P" for w in widgets)

--- a/textui/defs/element_widget_definition.py
+++ b/textui/defs/element_widget_definition.py
@@ -63,12 +63,11 @@ def preprocess_script(element: Element, app: App) -> bool:
     script_code = element.text or ""
 
     if language in ("py", "python") and script_code.strip():
-        try:
-            exec(script_code, {"app": app})
-        except Exception:
-            logging.exception("Error executing script node")
+        app._scripts.append(script_code)
     else:
-        logging.warning("Ignoring script with unsupported language '%s'", language)
+        logging.warning(
+            "Ignoring script with unsupported language '%s'", language
+        )
 
     return False
 

--- a/textui/textui.py
+++ b/textui/textui.py
@@ -14,6 +14,7 @@ class TextUI(App):
     def __init__(self, markup: str) -> None:
         super().__init__()
         self.widget_factory = ElementWidgetFactory()
+        self._scripts: list[str] = []
 
         if os.path.isfile(markup):
             self.markup_path = os.path.abspath(markup)
@@ -89,6 +90,18 @@ class TextUI(App):
         for widget in composed_widgets:
             logging.info(f"Composed widget: {widget}")
             yield widget
+
+    def run_scripts(self) -> None:
+        """Execute scripts collected during preprocessing."""
+        for script in self._scripts:
+            try:
+                exec(script, {"app": self})
+            except Exception:
+                logging.exception("Error executing script node")
+        self._scripts.clear()
+
+    async def on_mount(self) -> None:
+        self.run_scripts()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- gather scripts during preprocessing and execute them after widgets are created
- run stored scripts from `TextUI.on_mount`
- update tests to mount the app before checking script effects

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840767aeb4c8325881a00c2dcd36ffe